### PR TITLE
Fix margin on NextUp__header

### DIFF
--- a/src/components/NextUp/NextUp.css
+++ b/src/components/NextUp/NextUp.css
@@ -114,7 +114,8 @@
     margin: 0 auto;
   }
 
-  a.NextUp__link + a.NextUp__link .NextUp__container {
+  a.NextUp__link + a.NextUp__link .NextUp__container,
+  a.NextUp__link + a.NextUp__link .NextUp__header {
     margin-top: 16px;
   }
 }


### PR DESCRIPTION
Add margin-top: 16px to all NextUp__headers after a NextUp__link